### PR TITLE
Update person-tracker-card.js

### DIFF
--- a/person-tracker-card.js
+++ b/person-tracker-card.js
@@ -690,8 +690,9 @@ class PersonTrackerCard extends LitElement {
     else if (this._activity === 'Automotive') activityColor = 'blue';
     
     // Connection
-    const connectionIcon = this._connectionType === 'Wi-Fi' ? 'mdi:wifi' : 'mdi:signal';
-    const connectionColor = this._connectionType === 'Wi-Fi' ? 'blue' : 'orange';
+    const type = this._connectionType.toLowerCase().replace(/[^a-z]/g, '');
+    const connectionIcon = type === 'wifi' ? 'mdi:wifi' : 'mdi:signal';
+    const connectionColor = type === 'wifi' ? 'blue' : 'orange';
     
     // Battery color
     const batteryColor = this._getBatteryColor();


### PR DESCRIPTION
Hi, for Android Companion App, network_type sensor uses `wifi` instead of `Wi-Fi` value like iOS. 
Changing the checks on wifi word, we could see the same thing you do in an iPhone, letting all the possibilties also for "Wi-Fi", "wi fi", "WIFI", etc.