### PR TITLE
📝 Fix release date for v1.2.4 in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.4] - 2024-12-04
+## [1.2.4] - 2025-12-04
 
 ### Fixed
 - Fixed German (de) translations encoding issues (ä, ö, ü, ß characters were corrupted)


### PR DESCRIPTION
This PR fixes the release date for version 1.2.4 in CHANGELOG.md from 2024-12-04 to 2025-12-04.